### PR TITLE
Prepare v0.1.1

### DIFF
--- a/certbot.sh
+++ b/certbot.sh
@@ -33,9 +33,9 @@ until [  $COUNTER -lt 1 ]; do
     dom="$dom -d $i"
   done
 
-  printf "\nUse certbot --standalone --non-interactive --cert-name ${arr[0]} --expand --keep-until-expiring --agree-tos --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp  $dom";
+  printf "\nUse certbot-auto certonly --no-self-upgrade --standalone --non-interactive --cert-name ${arr[0]} --expand --keep-until-expiring --agree-tos --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp  $dom";
 
-  certbot-auto certonly --standalone --non-interactive --cert-name ${arr[0]} --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
+  certbot-auto certonly --no-self-upgrade --standalone --non-interactive --cert-name ${arr[0]} --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
 
   let COUNTER-=1
 done

--- a/certbot.sh
+++ b/certbot.sh
@@ -33,9 +33,9 @@ until [  $COUNTER -lt 1 ]; do
     dom="$dom -d $i"
   done
 
-  printf "\nUse certbot-auto certonly --no-self-upgrade --standalone --non-interactive --cert-name ${arr[0]} --expand --keep-until-expiring --agree-tos --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp  $dom";
+  printf "\nUse certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --agree-tos --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp  $dom";
 
-  certbot-auto certonly --no-self-upgrade --standalone --non-interactive --cert-name ${arr[0]} --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
+  certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
 
   let COUNTER-=1
 done

--- a/certbot.sh
+++ b/certbot.sh
@@ -33,10 +33,16 @@ until [  $COUNTER -lt 1 ]; do
     dom="$dom -d $i"
   done
 
-  printf "\nUse certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --agree-tos --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp  $dom";
+  # check if DOMAINDIRECTORY exists, if it exists use --cert-name to prevent 0001 0002 0003 folders
+  if [ -d "$DIRECTORY" ]; then
+    printf "\nUse certbot-auto certonly --cert-name ${arr[0]} --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp $dom \n";
+    certbot-auto certonly --no-self-upgrade --cert-name ${arr[0]} --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
+  else
+    printf "\nUse certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp $dom \n";
+    certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
+  fi
 
-  certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
-
+  
   let COUNTER-=1
 done
 

--- a/certbot.sh
+++ b/certbot.sh
@@ -34,7 +34,7 @@ until [  $COUNTER -lt 1 ]; do
   done
 
   # check if DOMAINDIRECTORY exists, if it exists use --cert-name to prevent 0001 0002 0003 folders
-  if [ -d "$DIRECTORY" ]; then
+  if [ -d "$DOMAINDIRECTORY" ]; then
     printf "\nUse certbot-auto certonly --cert-name ${arr[0]} --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp $dom \n";
     certbot-auto certonly --no-self-upgrade --cert-name ${arr[0]} --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
   else

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -10,7 +10,7 @@ printf "${GREEN}Hello! renewAndSendToProxy runs. Today is $(date)${NC}\n"
 #full path is needed or it is not started when run as cron
 /root/certbot-auto renew > /var/log/dockeroutput.log
 
-printf "Docker Flow: Proxy DNS-Name: ${GREEN}$PROXY_INSTANCE_NAME${NC}\n";
+printf "Docker Flow: Proxy DNS-Name: ${GREEN}$PROXY_ADDRESS${NC}\n";
 
 for d in /etc/letsencrypt/live/*/ ; do
     #move to directory
@@ -26,11 +26,11 @@ for d in /etc/letsencrypt/live/*/ ; do
     printf "${GREEN}generated $folder.combined.pem${NC}\n"
 
     #send to proxy
-    printf "${GREEN}transmit $folder.combined.pem to $PROXY_INSTANCE_NAME${NC}\n"
+    printf "${GREEN}transmit $folder.combined.pem to $PROXY_ADDRESS${NC}\n"
 
     curl -i -XPUT \
          --data-binary @$folder.combined.pem \
-         "$PROXY_INSTANCE_NAME:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log
+         "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log
 
     printf "proxy received $folder.combined.pem\n"
 

--- a/servicestart
+++ b/servicestart
@@ -16,4 +16,4 @@ printf "Starting Docker Flow: Let's Encrypt\n"
 
 printf "\033[0;31mStarting supervisord (which starts and monitors cron) \033[0m\n"
 
-/usr/bin/supervisord
+/usr/bin/supervisord -c etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
- disable auto-update of certbot-auto
- fixed PROXY_ADDRESS
- specify absolute path to supervisord config
- add `--cert-name` only when `folder` exists under /etc/letsencrypt/live/folder. New certificate overwrites old ones and no 0001 0002 0003 folders are created