### PR TITLE
Remove aclName not needed anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Attention! If you use local storage, create the `/etc/letsencrypt` folder before
 
 ```
 docker service create --name letsencrypt-companion \
-    --label com.df.aclName=__acme_letsencrypt_companion \
     --label com.df.notify=true \
     --label com.df.distribute=true \
     --label com.df.servicePath=/.well-known/acme-challenge \
@@ -86,7 +85,6 @@ services:
           - /etc/letsencrypt:/etc/letsencrypt
     deploy:
       labels:
-        - com.df.aclName=__acme_letsencrypt_companion # arbitrary aclName to make sure it's on top on HAProxy's list
         - com.df.servicePath=/.well-known/acme-challenge
         - com.df.notify=true
         - com.df.distribute=true

--- a/docker-compose-full-stack.yml
+++ b/docker-compose-full-stack.yml
@@ -45,7 +45,6 @@ services:
           - /etc/letsencrypt:/etc/letsencrypt
     deploy:
       labels:
-        - com.df.aclName=__acme_letsencrypt_companion # arbitrary aclName to make sure it's on top on HAProxy's list
         - com.df.servicePath=/.well-known/acme-challenge
         - com.df.notify=true
         - com.df.distribute=true


### PR DESCRIPTION
Removed the aclName from the example since docker-flow-proxy
updated the ordering on
https://github.com/vfarcic/docker-flow-proxy/issues/151