### PR TITLE
Add retry option to curl when uploading certificates

### DIFF
--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -50,8 +50,8 @@ for d in /etc/letsencrypt/live/*/ ; do
         printf "${RED}transmit failed after ${TRIES} attempts.${NC}\n"
       else
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
+        sleep $TIMEOUT
       fi
-      sleep $TIMEOUT
     done
 
     if [ $exitcode -eq 0 ]; then

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,7 +40,6 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
-      TRIES=$[$TRIES+1]
       curl -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break
@@ -52,6 +51,7 @@ for d in /etc/letsencrypt/live/*/ ; do
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
       fi
       sleep $TIMEOUT
+      TRIES=$[$TRIES+1]
     done
 
     if [ $exitcode -eq 0 ]; then

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -51,7 +51,7 @@ for d in /etc/letsencrypt/live/*/ ; do
       else
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
       fi
-      sleep TIMEOUT
+      sleep $TIMEOUT
     done
 
     if [ $exitcode -eq 0 ]; then

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,7 +40,7 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
-      curl -i -XPUT \
+      curl --silent --show-error -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break
       exitcode=$?

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,7 +40,7 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
-      n=$[$TRIES+1]
+      TRIES=$[$TRIES+1]
       curl -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,18 +40,18 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
+      TRIES=$[$TRIES+1]
       curl --silent --show-error -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break
       exitcode=$?
 
-      if [ $TRIES -eq 4 ]; then
+      if [ $TRIES -eq $MAXRETRIES ]; then
         printf "${RED}transmit failed after ${TRIES} attempts.${NC}\n"
       else
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
       fi
       sleep $TIMEOUT
-      TRIES=$[$TRIES+1]
     done
 
     if [ $exitcode -eq 0 ]; then


### PR DESCRIPTION
Using docker swarm it can happen that a docker-flow-letsencrypt container starts before a docker-flow-proxy container. When that is the case curl fails (stating it is unable to resolve host ...). So I added a retry mechanism and curl will try again if it fails. 