### PR TITLE
Add a dry-run (with a retry mechanism) to certbot.sh

### DIFF
--- a/certbot.sh
+++ b/certbot.sh
@@ -5,6 +5,12 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+#maximum number of retries
+MAXRETRIES=5
+
+#timeout
+TIMEOUT=5
+
 printf "${GREEN}Docker Flow: Let's Encrypt started${NC}\n";
 printf "We will use $CERTBOT_EMAIL for certificate registration with certbot. This e-mail is used by Let's Encrypt when you lose the account and want to get it back.\n";
 
@@ -13,6 +19,9 @@ if [ "$CERTBOTMODE" ]; then
   printf "${RED}Staging environment of Let's Encrypt is activated! The generated certificates won't be trusted. But you will not reach Let’s Encrypt's rate limits.${NC}\n";
   staging='--staging';
 fi
+
+#common arguments
+args=("--no-self-upgrade" "--standalone" "--non-interactive" "--expand" "--keep-until-expiring" "--email" "$CERTBOT_EMAIL" "--agree-tos" "$staging" "--preferred-challenges" "http-01" "--rsa-key-size" "4096" "--redirect" "--hsts" "--staple-ocsp")
 
 #we need to be careful and don't reach the rate limits of Let's Encrypt https://letsencrypt.org/docs/rate-limits/
 #Let's Encrypt has a certificates per registered domain (20 per week) and a names per certificate (100 subdomains) limit
@@ -30,16 +39,37 @@ until [  $COUNTER -lt 1 ]; do
   dom="";
   for i in "${arr[@]}"
   do
-    dom="$dom -d $i"
+    let exitcode=tries=0
+    until [ $tries -ge $MAXRETRIES ]
+    do
+      tries=$[$tries+1]
+      certbot-auto certonly --dry-run "${args[@]}" -d "$i" | grep -q 'The dry run was successful.' && break
+      exitcode=$?
+
+      if [ $tries -eq $MAXRETRIES ]; then
+        printf "${RED}Unable to verfiy domain ownership after ${tries} attempts.${NC}\n"
+      else
+        printf "${RED}Unable to verfiy domain ownership, we try again in ${TIMEOUT} seconds.${NC}\n"
+        sleep $TIMEOUT
+      fi
+    done
+
+    if [ $exitcode -eq 0 ]; then
+      printf "Domain $i successfully validated\n"
+      dom="$dom -d $i"
+    fi
   done
 
-  # check if DOMAINDIRECTORY exists, if it exists use --cert-name to prevent 0001 0002 0003 folders
-  if [ -d "$DOMAINDIRECTORY" ]; then
-    printf "\nUse certbot-auto certonly --cert-name ${arr[0]} --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp $dom \n";
-    certbot-auto certonly --no-self-upgrade --cert-name ${arr[0]} --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
-  else
-    printf "\nUse certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp $dom \n";
-    certbot-auto certonly --no-self-upgrade --standalone --non-interactive --expand --keep-until-expiring --email $CERTBOT_EMAIL $dom --agree-tos $staging --preferred-challenges http-01 --rsa-key-size 4096 --redirect --hsts --staple-ocsp
+  #only if we have successfully validated at least a single domain we have to continue
+  if [ -n "$dom" ]; then
+    # check if DOMAINDIRECTORY exists, if it exists use --cert-name to prevent 0001 0002 0003 folders
+    if [ -d "$DOMAINDIRECTORY" ]; then
+      printf "\nUse certbot-auto certonly %s --cert-name %s\n" "${args[*]}" "${arr[0]}";
+      certbot-auto certonly "${args[@]}" --cert-name "${arr[0]}" $dom
+    else
+      printf "\nUse certbot-auto certonly %s\n" "${args[*]}";
+      certbot-auto certonly "${args[@]}" $dom
+    fi
   fi
 
   

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -50,8 +50,8 @@ for d in /etc/letsencrypt/live/*/ ; do
         printf "${RED}transmit failed after ${TRIES} attempts.${NC}\n"
       else
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
+        sleep $TIMEOUT
       fi
-      sleep $TIMEOUT
     done
 
     if [ $exitcode -eq 0 ]; then

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,7 +40,6 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
-      TRIES=$[$TRIES+1]
       curl -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break
@@ -52,6 +51,7 @@ for d in /etc/letsencrypt/live/*/ ; do
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
       fi
       sleep $TIMEOUT
+      TRIES=$[$TRIES+1]
     done
 
     if [ $exitcode -eq 0 ]; then

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -51,7 +51,7 @@ for d in /etc/letsencrypt/live/*/ ; do
       else
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
       fi
-      sleep TIMEOUT
+      sleep $TIMEOUT
     done
 
     if [ $exitcode -eq 0 ]; then

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,7 +40,7 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
-      curl -i -XPUT \
+      curl --silent --show-error -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break
       exitcode=$?

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,7 +40,7 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
-      n=$[$TRIES+1]
+      TRIES=$[$TRIES+1]
       curl -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -40,18 +40,18 @@ for d in /etc/letsencrypt/live/*/ ; do
     exitcode=0
     until [ $TRIES -ge $MAXRETRIES ]
     do
+      TRIES=$[$TRIES+1]
       curl --silent --show-error -i -XPUT \
            --data-binary @$folder.combined.pem \
            "$PROXY_ADDRESS:8080/v1/docker-flow-proxy/cert?certName=$folder.combined.pem&distribute=true" > /var/log/dockeroutput.log && break
       exitcode=$?
 
-      if [ $TRIES -eq 4 ]; then
+      if [ $TRIES -eq $MAXRETRIES ]; then
         printf "${RED}transmit failed after ${TRIES} attempts.${NC}\n"
       else
         printf "${RED}transmit failed, we try again in ${TIMEOUT} seconds.${NC}\n"
       fi
       sleep $TIMEOUT
-      TRIES=$[$TRIES+1]
     done
 
     if [ $exitcode -eq 0 ]; then


### PR DESCRIPTION
When deploying a letsencrypt container via Docker swarm, the docker-flow-proxy might not be ready yet to redirect traffic to the letsencrypt container. This causes the domain validation to fail. To better handle this case I added a dry-run option before obtaining the actual certificates. This way invalid (test) certificates will be obtained first (but not persistently stored, see [this](http://letsencrypt.readthedocs.io/en/latest/using.html#changing-a-certificate-s-domains) link), so without having to worry about any limits we make sure Let's Encrypt is able to validate our domain(s). Only domains that are validated in the dry-run will be issued valid certificates. I still need to think about the case no domains can be successfully validated (this currently results in some nonsense being sent to the proxy, will make a bug for that).