### PR TITLE
Remove DOMAIN_COUNT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 FROM ubuntu:16.04
 
 #set default env variables
-ENV DOMAIN_COUNT=0 \
-    CERTBOT_EMAIL="" \
+ENV CERTBOT_EMAIL="" \
     PROXY_ADDRESS="proxy" \
     CERTBOT_CRON_RENEW="('0 3 * * *' '0 15* * *')" \
     PATH="$PATH:/root"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ docker service create --name letsencrypt-companion \
     --label com.df.port=80 \
     -e DOMAIN_1="('haembi.de' 'www.haembi.de' 'blog.haembi.de')"\
     -e DOMAIN_2="('michael-hamburger.de' 'www.michael-hamburger.de' 'blog.michael-hamburger.de')"\
-    -e DOMAIN_COUNT=2 \
     -e CERTBOT_EMAIL="your.mail@mail.de" \
     -e PROXY_ADDRESS="proxy" \
     -e CERTBOT_CRON_RENEW="('0 3 * * *' '0 15 * * *')"\
@@ -77,7 +76,6 @@ services:
     environment:
       - DOMAIN_1=('haembi.de' 'www.haembi.de' 'blog.haembi.de')
       - DOMAIN_2=('michael-hamburger.de' 'www.michael-hamburger.de' 'blog.michael-hamburger.de')
-      - DOMAIN_COUNT=2
       - CERTBOT_EMAIL=your.mail@mail.de
       - PROXY_ADDRESS=proxy
       - CERTBOT_CRON_RENEW=('0 3 * * *' '0 15 * * *')
@@ -104,7 +102,7 @@ You should always start the service on the same docker host. You achieve this by
 You must not scale the service to two, this wouldn't make any sense! Only one instance of this companion should run.
 The certificates are only renewed when they are 60 days old or older. This is standard certbot-auto behavior. But the certificates will be renewed when you add subdomains to the domain-list! If you want to change the number of times certbot-auto renew and the publish script is called you need to change CERTBOT_CRON_RENEW. The syntax is described [here](http://www.adminschoice.com/crontab-quick-reference). 
 
-Important: DOMAIN_COUNT needs to be the number of Domains you want certificates generated. The first domain must always be the domain without any subdomains. That makes the folder-structure regular.
+Important: The first domain must always be the domain without any subdomains. That makes the folder-structure regular.
 
 We need to obey Let’s Encrypt’s rate limits! https://letsencrypt.org/docs/rate-limits/
 

--- a/certbot.sh
+++ b/certbot.sh
@@ -29,7 +29,7 @@ fi
 #Let's Encrypt has a certificates per registered domain (20 per week) and a names per certificate (100 subdomains) limit
 #so we should create ONE certificiates for a certain domain and add all their subdomains (max 100!)
 
-for var in $(env | grep 'DOMAIN_' | sed  -e 's/=.*//'); do
+for var in $(env | grep -P 'DOMAIN_\d+' | sed  -e 's/=.*//'); do
   cur_domains=${!var};
 
   declare -a arr=$cur_domains;

--- a/certbot.sh
+++ b/certbot.sh
@@ -32,10 +32,7 @@ args=("--no-self-upgrade" "--standalone" "--non-interactive" "--expand" "--keep-
 #Let's Encrypt has a certificates per registered domain (20 per week) and a names per certificate (100 subdomains) limit
 #so we should create ONE certificiates for a certain domain and add all their subdomains (max 100!)
 
-COUNTER=$DOMAIN_COUNT;
-
-until [  $COUNTER -lt 1 ]; do
-  var="DOMAIN_$COUNTER";
+for var in $(env | grep 'DOMAIN_' | sed  -e 's/=.*//'); do
   cur_domains=${!var};
 
   declare -a arr=$cur_domains;
@@ -77,8 +74,6 @@ until [  $COUNTER -lt 1 ]; do
     fi
   fi
 
-  
-  let COUNTER-=1
 done
 
 #prepare renewcron

--- a/certbot.sh
+++ b/certbot.sh
@@ -25,9 +25,6 @@ if [ "$CERTBOTMODE" ]; then
   args+=("--staging");
 fi
 
-#common arguments
-args=("--no-self-upgrade" "--standalone" "--non-interactive" "--expand" "--keep-until-expiring" "--email" "$CERTBOT_EMAIL" "--agree-tos" "$staging" "--preferred-challenges" "http-01" "--rsa-key-size" "4096" "--redirect" "--hsts" "--staple-ocsp")
-
 #we need to be careful and don't reach the rate limits of Let's Encrypt https://letsencrypt.org/docs/rate-limits/
 #Let's Encrypt has a certificates per registered domain (20 per week) and a names per certificate (100 subdomains) limit
 #so we should create ONE certificiates for a certain domain and add all their subdomains (max 100!)

--- a/docker-compose-full-stack.yml
+++ b/docker-compose-full-stack.yml
@@ -37,7 +37,6 @@ services:
     environment:
       - DOMAIN_1=('haembi.de' 'www.haembi.de' 'blog.haembi.de')
       - DOMAIN_2=('michael-hamburger.de' 'www.michael-hamburger.de' 'blog.michael-hamburger.de')
-      - DOMAIN_COUNT=2
       - CERTBOT_EMAIL=your.mail@mail.de
       - PROXY_ADDRESS=proxy
       - CERTBOT_CRON_RENEW=('0 3 * * *' '0 15 * * *')

--- a/docker-compose-stack.yml
+++ b/docker-compose-stack.yml
@@ -10,7 +10,6 @@ services:
     environment:
       - DOMAIN_1=('haembi.de' 'www.haembi.de' 'blog.haembi.de')
       - DOMAIN_2=('michael-hamburger.de' 'www.michael-hamburger.de' 'blog.michael-hamburger.de')
-      - DOMAIN_COUNT=2
       - CERTBOT_EMAIL=your.mail@mail.de
       - PROXY_ADDRESS=proxy
       - CERTBOT_CRON_RENEW=('0 3 * * *' '0 15 * * *')

--- a/run
+++ b/run
@@ -5,7 +5,6 @@ docker service create --name letsencrypt-companion \
     --label com.df.port=80 \
     -e DOMAIN_1="('haembi.de' 'www.haembi.de' 'blog.haembi.de')"\
     -e DOMAIN_2="('michael-hamburger.de' 'www.michael-hamburger.de' 'blog.michael-hamburger.de')"\
-    -e DOMAIN_COUNT=2 \
     -e CERTBOT_EMAIL="michael.hamburger@mail.de" \
     -e PROXY_ADDRESS="proxy" \
     -e CERTBOT_CRON_RENEW="('0 3 * * *' '0 15 * * *')"\

--- a/servicestart
+++ b/servicestart
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ $DOMAIN_COUNT -lt 1 ]; then
-    printf "DOMAIN_COUNT is zero or lower!"
-    exit 1
-fi
-
 if [ -z $CERTBOT_EMAIL ]; then
     printf "CERTBOT_EMAIL is empty!"
     exit 1


### PR DESCRIPTION
Closes #3

Remove useless `DOMAIN_COUNT` variable what makes automatic management easier now.
There's no need to use numbers next by next now, you can use `DOMAIN_1`, `DOMAIN_14` and `DOMAIN_666` without any problem without numbers between.

This change is backward-compatible, and will not use `DOMAIN_COUNT` when grepping throught variables. See this change (in `certbot.sh`):

```bash
env | grep -P 'DOMAIN_\d+'
```

If you configure DFLE automatically from (for eg.) MySQL, you don't need to remap ids. You can use IDs directly stored in DB.