### PR TITLE
Make Docker image smaller + some fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,23 @@
 FROM ubuntu:16.04
 
 #set default env variables
-ENV DOMAIN_COUNT=0 \
+ENV DEBIAN_FRONTEND=noninteractive \
     CERTBOT_EMAIL="" \
     PROXY_ADDRESS="proxy" \
     CERTBOT_CRON_RENEW="('0 3 * * *' '0 15* * *')" \
     PATH="$PATH:/root"
 
 # http://stackoverflow.com/questions/33548530/envsubst-command-getting-stuck-in-a-container
-RUN apt-get update && apt-get -y install cron && apt-get install -y supervisor && apt-get install -y wget && apt-get install -y curl
+RUN apt-get update && \
+    apt-get -y install cron supervisor curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install certbot-auto
-RUN cd /root && wget https://dl.eff.org/certbot-auto
-RUN chmod a+x /root/certbot-auto
-RUN ./root/certbot-auto --version --non-interactive
-RUN PATH=$PATH:/root
+RUN curl -o /root/certbot-auto https://dl.eff.org/certbot-auto && \
+    chmod a+x /root/certbot-auto && \
+    /root/certbot-auto --version --non-interactive && \
+    apt-get purge -y --auto-remove gcc libc6-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add supervisord.conf
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf 
@@ -30,13 +33,13 @@ RUN chmod u+x /root/renewAndSendToProxy.sh
 RUN ln -sf /proc/1/fd/1 /var/log/dockeroutput.log
 
 # Add symbolic link in cron.daily directory without ending (important!)
-ADD renewcron /etc/cron.d/renewcron 
-RUN chmod u+x /etc/cron.d/renewcron 
+ADD renewcron /etc/cron.d/renewcron
+RUN chmod u+x /etc/cron.d/renewcron
 
 ADD servicestart /root/servicestart
 RUN chmod u+x /root/servicestart
 
 # Run the command on container startup
-CMD ["bin/bash", "/root/servicestart"]
+CMD ["/root/servicestart"]
 
 EXPOSE 80

--- a/servicestart
+++ b/servicestart
@@ -16,4 +16,4 @@ printf "Starting Docker Flow: Let's Encrypt\n"
 
 printf "\033[0;31mStarting supervisord (which starts and monitors cron) \033[0m\n"
 
-/usr/bin/supervisord -c etc/supervisor/conf.d/supervisord.conf
+/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
- cleanup whitespaces
- use absolute paths to supervisor config and certbot-auto download path
- do apt-get install at once (image size: 480MB -> 453MB)
- cleanup apt after doing work (image size: 453MB -> 415MB)
- remove wget and use only curl to downloading certbot-auto (image size: 415MB -> 414MB)
- remove gcc and *-dev packages after they are used by certbot bootstrap (image size: size 414MB -> 267MB)

See progress:
```
openhades/docker-flow-letsencrypt   <none>              e697391bbe8f        21 minutes ago      267.6 MB
openhades/docker-flow-letsencrypt   <none>              86bc957d6837        About an hour ago   414.7 MB
openhades/docker-flow-letsencrypt   <none>              cde7e51c1c2b        About an hour ago   415.3 MB
openhades/docker-flow-letsencrypt   <none>              b64d567b3a7a        About an hour ago   453.5 MB
hamburml/docker-flow-letsencrypt    <none>              8b06c0ea012f        4 weeks ago         480 MB
```

I'm not sure if this is correct way to do this since there is `certbot-auto`, but… it's started with `--no-self-upgrade` anyway, so…

**Merge this AFTER #21 or you'll have broken ENV!**