### PR TITLE
docker multiarch support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: required
+
+language: bash
+
+service:
+    - docker
+
+before_install:
+    - wget https://github.com/clnperez/cli/releases/download/1.0/docker-linux-amd64
+    - chmod 755 docker-linux-amd64
+    - docker pull multiarch/qemu-user-static:register
+    - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+script:
+    - make arm64v8
+    - make amd64
+    - make arm32v7
+
+
+after_success:
+    - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+    - docker push $REPO/$IMAGE_NAME:amd64
+    - docker push $REPO/$IMAGE_NAME:arm32v7
+    - docker push $REPO/$IMAGE_NAME:arm64v8
+    - ./docker-linux-amd64 -v 
+    - ./docker-linux-amd64 manifest create $REPO/$IMAGE_NAME:latest $REPO/$IMAGE_NAME:amd64 $REPO/$IMAGE_NAME:arm32v7 $REPO/$IMAGE_NAME:arm64v8 -a
+    - ./docker-linux-amd64 manifest inspect $REPO/$IMAGE_NAME:latest
+    - ./docker-linux-amd64 manifest annotate $REPO/$IMAGE_NAME:latest $REPO/$IMAGE_NAME:amd64
+    - ./docker-linux-amd64 manifest annotate $REPO/$IMAGE_NAME:latest $REPO/$IMAGE_NAME:arm32v7 --os linux --arch arm
+    - ./docker-linux-amd64 manifest annotate $REPO/$IMAGE_NAME:latest $REPO/$IMAGE_NAME:arm64v8 --os linux --arch arm64 --variant armv8
+    - ./docker-linux-amd64 manifest push $REPO/$IMAGE_NAME:latest

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,46 @@
+FROM __BASEIMAGE_ARCH__/ubuntu:16.04
+ARG ARCH=__BASEIMAGE_ARCH__
+__CROSS_COPY qemu-__QEMU_ARCH__-static /usr/bin/qemu-__QEMU_ARCH__-static
+
+#set default env variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    CERTBOT_EMAIL="" \
+    PROXY_ADDRESS="proxy" \
+    CERTBOT_CRON_RENEW="('0 3 * * *' '0 15 * * *')" \
+    PATH="$PATH:/root"
+
+# http://stackoverflow.com/questions/33548530/envsubst-command-getting-stuck-in-a-container
+RUN apt-get update && \
+    apt-get -y install cron supervisor curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# install certbot-auto
+RUN curl -o /root/certbot-auto https://dl.eff.org/certbot-auto && \
+    chmod a+x /root/certbot-auto && \
+    /root/certbot-auto --version --non-interactive && \
+    apt-get purge -y --auto-remove gcc libc6-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add supervisord.conf
+ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf 
+
+# Add certbot and make it executable
+ADD certbot.sh /root/certbot.sh
+RUN chmod u+x /root/certbot.sh
+
+ADD renewAndSendToProxy.sh /root/renewAndSendToProxy.sh
+RUN chmod u+x /root/renewAndSendToProxy.sh
+
+RUN ln -sf /proc/1/fd/1 /var/log/dockeroutput.log
+
+# Add symbolic link in cron.daily directory without ending (important!)
+ADD renewcron /etc/cron.d/renewcron
+RUN chmod u+x /etc/cron.d/renewcron
+
+ADD servicestart /root/servicestart
+RUN chmod u+x /root/servicestart
+
+# Run the command on container startup
+CMD ["/root/servicestart"]
+
+EXPOSE 80

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+
+
+		
+amd64:
+		cp Dockerfile.cross Dockerfile.amd64
+		sed -i "s|__BASEIMAGE_ARCH__|amd64|g" Dockerfile.amd64
+		sed -i "s|__QEMU_ARCH__|x86_64|g" Dockerfile.amd64
+		sed -i "/__CROSS_/d" Dockerfile.amd64
+		cat Dockerfile.amd64
+		docker build -f Dockerfile.amd64 -t $(REPO)/$(IMAGE_NAME):amd64 .
+  		docker push $(REPO)/$(IMAGE_NAME):amd64
+
+arm64v8:
+		cp Dockerfile.cross Dockerfile.arm64v8
+		sed -i "s|__BASEIMAGE_ARCH__|arm64v8|g" Dockerfile.arm64v8
+		sed -i "s|__QEMU_ARCH__|aarch64|g" Dockerfile.arm64v8
+		sed -i  "s/__CROSS_//g" Dockerfile.arm64v8
+		cat Dockerfile.arm64v8
+		wget https://github.com/multiarch/qemu-user-static/releases/download/v2.12.0/qemu-aarch64-static
+		chmod 755 qemu-aarch64-static
+		docker build --build-arg ARCH=arm64v8 --no-cache -f Dockerfile.arm64v8 -t $(REPO)/$(IMAGE_NAME):arm64v8 .
+  		docker push $(REPO)/$(IMAGE_NAME):arm64v8
+
+arm32v7:
+		cp Dockerfile.cross Dockerfile.arm32v7
+		sed -i "s|__BASEIMAGE_ARCH__|arm32v7|g" Dockerfile.arm32v7
+		sed -i "s|__QEMU_ARCH__|arm|g" Dockerfile.arm32v7
+		sed -i  "s/__CROSS_//g" Dockerfile.arm32v7
+		cat Dockerfile.arm32v7
+		wget https://github.com/multiarch/qemu-user-static/releases/download/v2.12.0/qemu-arm-static
+		chmod 755 qemu-arm-static 
+		docker build --build-arg ARCH=arm32v7 --no-cache -f Dockerfile.arm32v7 -t $(REPO)/$(IMAGE_NAME):arm32v7 .
+  		docker push $(REPO)/$(IMAGE_NAME):arm32v7


### PR DESCRIPTION
Thank you - Michael - for this docker-flow-proxy add-on 
please find attached a

PR: add multi architecture support via travis-ci pipeline
- arm64v8, arm32v7 & amd64 images
- manifest :latest with multi architecture support
  (no need to specify architecture during pull)

pipeline needs 4 variables on travis-ci
```DOCKER_USERNAME``` ```DOCKER_PASSWORD``` ```REPO``` ```IMAGE_NAME```

please check output on docker-hub holgerimbery/docker-flow-letsencrypt for reference