### PR TITLE
Fixed bug in retry logic, updated to Bionic and updated certbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-#use 16.04 lts, install certbot-auto to get newest certbot version
-FROM ubuntu:16.04
+#use 18.04 lts
+FROM ubuntu:18.04
 
 #set default env variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -10,14 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # http://stackoverflow.com/questions/33548530/envsubst-command-getting-stuck-in-a-container
 RUN apt-get update && \
-    apt-get -y install cron supervisor curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# install certbot-auto
-RUN curl -o /root/certbot-auto https://dl.eff.org/certbot-auto && \
-    chmod a+x /root/certbot-auto && \
-    /root/certbot-auto --version --non-interactive && \
-    apt-get purge -y --auto-remove gcc libc6-dev && \
+    apt-get -y install cron supervisor curl certbot && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add supervisord.conf

--- a/renewAndSendToProxy.sh
+++ b/renewAndSendToProxy.sh
@@ -58,9 +58,9 @@ done
 
 #full path is needed or it is not started when run as cron
 
-#--no-bootstrap: prevent the certbot-auto script from installing OS-level dependencies
-#--no-self-upgrade: revent the certbot-auto script from upgrading itself to newer released versions
-/root/certbot-auto renew --no-bootstrap --no-self-upgrade > /var/log/dockeroutput.log
+#--no-bootstrap: prevent certbot from installing OS-level dependencies
+#--no-self-upgrade: prevent certbot from upgrading itself to newer released versions
+certbot renew --no-bootstrap --no-self-upgrade > /var/log/dockeroutput.log
 
 echo $PROXY_ADDRESS | tr ',' '\n' | while read proxy_addr; do
 	printf "Docker Flow: Proxy DNS-Name: ${GREEN}$proxy_addr${NC}\n";


### PR DESCRIPTION
I was impacted by a bug in the retry login in `certbot.sh` that would lead to a domain being skipped if it the certbot dry-run did not succeed on the first attempt (this was common in my case, for a service that was launching at the same time as this container). In short, the `break` statement would prevent `$exitcode` being set, which means that even when the dry-run eventually succeeded, this success was not detected. To fix this I refactored the logic a little.

In addition, I had to replace the `certbot-auto` script, which is now deprecated and [no longer works on Debian systems](https://community.letsencrypt.org/t/certbot-auto-no-longer-works-on-debian-based-systems/139702/7). While I was at it, I also upgraded to Ubuntu 18.04 LTS.